### PR TITLE
GitHub auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ bmcert --help
 
 `bmcert` relies on two environment variables
 ```
-VAULT_TOKEN=<your vault token>
-VAULT_CERT_URL=<path to your vault pki endpoint>
+# your github token
+VAULT_GITHUB_TOKEN=<token here>
+
+# vault server url
+VAULT_ADDR=https://vault.mynet.com:8200
+
+# full URL to vault server, including the pki path
+VAULT_CERT_URL=https://vault.mynet.com:8200/v1/<pki endpoint>
 ```
 
 ## Usage

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,3 +1,11 @@
+/*
+bmcert/auth manages retriving authentication tokens from a
+vault server. bmcert/auth relies upon the following environment
+variables in order to function:
+
+VAULT_ADDR          // https://vault.mynet.com:8200
+VAULT_GITHUB_TOKEN  // required for github auth
+*/
 package auth
 import (
 	"fmt"

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -58,13 +58,16 @@ func GetVaultAuthUrl() string {
 
     // vault addr includes the protocol and port
     // https://vault.mynetwork.net:8200
-	return url + "/v1/auth/github/login"
+	return url + "/v1/auth"
 }
 
 
 // authenticates against vault with a github token
 // returns github token as a string
 func GithubAuth() string {
+    var authurl string = GetVaultAuthUrl() + "/github/login"
+
+
     // get the github token from the environment
 	token := os.Getenv("VAULT_GITHUB_TOKEN")
     if len(token) == 0 {
@@ -74,7 +77,7 @@ func GithubAuth() string {
 
 
 	// create the http request
-	req, err := http.NewRequest("POST", GetVaultAuthUrl(), bytes.NewBuffer([]byte("{\"token\": \"" + token + "\"}")))
+	req, err := http.NewRequest("POST", authurl, bytes.NewBuffer([]byte("{\"token\": \"" + token + "\"}")))
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -63,7 +63,7 @@ func GetVaultAuthUrl() string {
 
 
 // authenticates against vault with a github token
-// returns github token as a string
+// returns vault token as a string
 func GithubAuth() string {
     var authurl string = GetVaultAuthUrl() + "/github/login"
 

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,4 +1,4 @@
-package cmd
+package auth
 import (
 	"fmt"
 	"os"

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,5 +1,5 @@
 /*
-bmcert/auth manages retriving authentication tokens from a
+bmcert/auth manages retrieving authentication tokens from a
 vault server. bmcert/auth relies upon the following environment
 variables in order to function:
 

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,0 +1,108 @@
+package cmd
+import (
+	"fmt"
+	"os"
+	"net/http"
+	"bytes"
+	"io/ioutil"
+	"encoding/json"
+)
+
+
+type GithubAuthResp struct {
+	Request_id string      `json:"request_id"`
+	Lease_id   string      `json:"lease_id"`
+	Renewable  bool        `json:"renewable"`
+	Lease_duration float32 `json:"lease_duration"`
+	Data       string 	   `json:"data"`
+	Wrap_info  string      `json:"wrap_info"`
+	Warnings   string      `json:"warnings"`
+	Auth       GithubAuthData `json:"auth"`
+}
+
+
+type GithubAuthData struct {
+	Client_token   string   `json:"client_token"`
+	Accessor       string   `json:"accessor"`
+	Policies       []string `json:"policies"`
+	Token_policies []string `json:"token_policies"`
+	Metadata       GithubMetadata `json:"metadata"`
+	Lease_duration float32  `json:"lease_duration"`
+	Renewable      bool     `json:"renewable"`
+	Entity_id      string   `json:"entity_id"`
+}
+
+
+type GithubMetadata struct {
+    Org      string `json:"org"`
+    Username string `json:"username"`
+}
+
+
+// returns the full URL for github auth endpoint
+// relies upon VAULT_ADDR environment variable
+func GetVaultAuthUrl() string {
+	url := os.Getenv("VAULT_ADDR")
+	if len(url) == 0 {
+		fmt.Println("Could not read environment VAULT_ADDR")
+		os.Exit(1)
+	}
+
+    // vault addr includes the protocol and port
+    // https://vault.mynetwork.net:8200
+	return url + "/v1/auth/github/login"
+}
+
+
+// authenticates against vault with a github token
+// returns github token as a string
+func GithubAuth() string {
+    // get the github token from the environment
+	token := os.Getenv("VAULT_GITHUB_TOKEN")
+    if len(token) == 0 {
+        fmt.Println("Could not read environment VAULT_GITHUB_TOKEN")
+		os.Exit(1)
+    }
+
+
+	// create the http request
+	req, err := http.NewRequest("POST", GetVaultAuthUrl(), bytes.NewBuffer([]byte("{\"token\": \"" + token + "\"}")))
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+
+	// create a http client, and perform the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+
+	// handle the http response, be silent if auth success
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	} else if resp.StatusCode != 200 {
+        fmt.Println("Vault response status:", resp.Status)
+		fmt.Println("Github auth response Body:", string(body))
+		os.Exit(1)
+	}
+
+
+	// unmarshal the response and return the token
+	var r GithubAuthResp
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
+	return r.Auth.Client_token
+}

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -1,3 +1,3 @@
 package cmd
 
-const VERSION = "0.1.1"
+const VERSION = "0.1.2"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -102,7 +102,7 @@ func createCertificate() {
 
 
 func requestCertificate() ApiResponse {
-	var url string = GetVaultUrl()
+	var url string = GetVaultPkiUrl()
 
 	// create the json payload
 	payload, err := json.Marshal(request)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,8 @@ import (
 	"fmt"
 	"os"
 
+	"bmcert/auth"
+
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +54,7 @@ func GetVaultToken() string {
 	var token string
 
 	if githubauth == true {
-		token = GithubAuth()
+		token = auth.GithubAuth()
 		if len(token) == 0 {
 			fmt.Println("Failed to get vault token using github token")
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,13 +29,14 @@ func init() {
 	// global arguments
 	rootCmd.PersistentFlags().BoolVarP(&skipverify, "tls-skip-verify", "", false, "Disable certificate verification when communicating with the Vault API (Defaults to false)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Enable verbose output --verbose")
+	rootCmd.PersistentFlags().BoolVarP(&githubauth, "github-auth", "", true, "Enable github authentication")
 }
 
 
 
 // returns the full URL for the VAULT PKI endpoint
 // example: https://vault.localnet:8200/v1/pki/issue/myrole
-func GetVaultUrl() string {
+func GetVaultPkiUrl() string {
 	url := os.Getenv("VAULT_CERT_URL")
 	if len(url) == 0 {
 		fmt.Println("Could not read environment VAULT_CERT_URL")
@@ -45,13 +46,26 @@ func GetVaultUrl() string {
 }
 
 
-
-// returns the vault token
+// returns the vault token with the selected authentication
+// method
 func GetVaultToken() string {
-	token := os.Getenv("VAULT_TOKEN")
-	if len(token) == 0 {
-		fmt.Println("Could not read environment VAULT_TOKEN")
-		os.Exit(1)
+	var token string
+
+	if githubauth == true {
+		token = GithubAuth()
+		if len(token) == 0 {
+			fmt.Println("Failed to get vault token using github token")
+			os.Exit(1)
+		}
+
+	// static token is the last resort
+	} else {
+		token = os.Getenv("VAULT_TOKEN")
+		if len(token) == 0 {
+			fmt.Println("Could not read environment VAULT_TOKEN")
+			os.Exit(1)
+		}
 	}
+
 	return token
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,7 +29,7 @@ func init() {
 	// global arguments
 	rootCmd.PersistentFlags().BoolVarP(&skipverify, "tls-skip-verify", "", false, "Disable certificate verification when communicating with the Vault API (Defaults to false)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "", false, "Enable verbose output --verbose")
-	rootCmd.PersistentFlags().BoolVarP(&githubauth, "github-auth", "", true, "Enable github authentication")
+	rootCmd.PersistentFlags().BoolVarP(&githubauth, "github-auth", "", true, "Github authentication (-github-auth=false to disable)")
 }
 
 

--- a/cmd/vars.go
+++ b/cmd/vars.go
@@ -9,3 +9,4 @@ Global variables live here
 
 var skipverify bool
 var verbose    bool
+var githubauth bool


### PR DESCRIPTION
## Purpose of this PR
Added support for Github authentication. Github is now the default method for authentication. Relying on a static token is easy, but a poor choice for security reasons. When using Github tokens, `bmcert` will retrieve a new `vault token` every time it makes a request. This allows us to use ACLs with Github groups to perform granular permission assignment. 

## Usage Requirements
Required environment variables for github auth are:
```
VAULT_GITHUB_TOKEN=<some token>
VAULT_CERT_URL=https://vault.mynet.com:8200/v1/<some pki path>
VAULT_ADDR=https://vault.mynet.com:8200
```

Using `VAULT_TOKEN` is still supported, however, you must pass `-github-auth=false`. It is easier to use a github token. This option should not be used. 

## Changes
Authentication is abstracted with the `bmcert/auth` package. Existing functions in `cmd/root.go` call out to `auth.GithubAuth()` to retrieve their vault token, instead of reading the `VAULT_TOKEN` env variable. 

## Testing
Unset the `VAULT_TOKEN` env variable

Add `VAULT_GITHUB_TOKEN` and `VAULT_ADDR` variables (see me for help)

Create a certificate:
```
bmcert create --hostname <fqdn> --tls-skip-verify
```