### PR TITLE
Build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # ignore binary build
 bmcert
+*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # ignore binary build
 bmcert
 *.zip
+*SHA256SUMS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,64 @@
+
+# staging environment retrieves dependencies and compiles
+# for Linux and MacOS
+FROM golang:1.12 AS stage
+
+WORKDIR /build/src/bmcert
+ARG token
+ARG addr
+ARG url
+ARG version
+ENV VAULT_GITHUB_TOKEN=$token
+ENV VAULT_ADDR=$addr
+ENV VAULT_CERT_URL=$url
+ENV GOPATH=/build
+
+ADD . /build/src/bmcert
+
+RUN \
+    go get github.com/spf13/cobra && \
+    go get github.com/BlueMedoraPublic/go-pkcs12 && \
+    go get github.com/hashicorp/vault/sdk/helper/certutil
+
+RUN go test ./...
+
+RUN env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bmcert-linux
+RUN env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o bmcert-darwin
+
+
+# perform tests with compiled binary
+FROM debian:stable AS test
+
+ARG token
+ARG addr
+ARG url
+ENV VAULT_GITHUB_TOKEN=$token
+ENV VAULT_ADDR=$addr
+ENV VAULT_CERT_URL=$url
+
+COPY --from=stage /build/src/bmcert/bmcert-linux bmcert
+
+RUN apt-get update && apt-get install -y openssl
+
+RUN ./bmcert create --hostname test.bluemedora.localnet --tls-skip-verify
+RUN ./bmcert create --hostname test.bluemedora.localnet --tls-skip-verify --format p12
+RUN ./bmcert create --hostname test.bluemedora.localnet --tls-skip-verify --format cert
+
+RUN openssl x509 -in test.bluemedora.localnet.pem -text -noout
+
+# build the release with an image that includes zip and sha256sum
+FROM debian:stable
+
+WORKDIR /
+ARG version
+
+RUN apt-get update && apt-get install zip -y
+
+COPY --from=stage /build/src/bmcert/bmcert-linux bmcert
+RUN zip bmcert-v${version}-linux-amd64.zip bmcert
+
+COPY --from=stage /build/src/bmcert/bmcert-darwin bmcert
+RUN zip bmcert-v${version}-darwin-amd64.zip bmcert
+
+RUN sha256sum bmcert-v${version}-linux-amd64.zip >> bmcert-v${version}.SHA256SUMS
+RUN sha256sum bmcert-v${version}-darwin-amd64.zip >> bmcert-v${version}.SHA256SUMS

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,105 @@
+#!/usr/bin/env groovy
+import groovy.json.JsonOutput
+def disableSlack = false
+def slackNotificationChannel = 'devops-jenkins'     // ex: = "builds"
+def notifySlack(text, channel, attachments, slackURL) {
+
+    def jenkinsIcon = 'https://wiki.jenkins-ci.org/download/attachments/2916393/logo.png'
+
+    def payload = JsonOutput.toJson([text: text,
+                                     channel: channel,
+                                     username: "Jenkins",
+                                     icon_url: jenkinsIcon,
+                                     attachments: attachments
+    ])
+
+    sh "curl -X POST --data-urlencode \'payload=${payload}\' ${slackURL}"
+}
+
+pipeline {
+    agent {
+        label "docker"
+    }
+    environment {
+        SLACK_HOOK_URL = credentials('SLACK_HOOK_URL')
+        VAULT_ADDR = credentials('VAULT_ADDR')
+        VAULT_CERT_URL = credentials('VAULT_CERT_URL')
+        VAULT_GITHUB_TOKEN = credentials('VAULT_GITHUB_TOKEN')
+    }
+    stages {
+        stage('Checkout SCM') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Run build script') {
+            steps {
+                    sh '''
+            rm -f *.zip
+            ./build.sh
+            '''
+            }
+        }
+    }
+    post {
+        always {
+            script {
+                //populateGlobalVariables()
+                def buildColor = currentBuild.result == null ? "good" : "warning"
+                def buildStatus = currentBuild.result == null ? "Success" : currentBuild.result
+                def jobName = "${env.JOB_NAME}"
+                def slack_hook_url = "${env.SLACK_HOOK_URL}"
+
+                // Strip the branch name out of the job name (ex: "Job Name/branch1" -> "Job Name")
+                jobName = jobName.getAt(0..(jobName.indexOf('/') - 0))
+
+                echo jobName
+                if (disableSlack == false){
+                if (buildStatus == "Failed") {
+                    buildStatus = "Failed"
+                    buildColor = "danger"
+                    notifySlack("", slackNotificationChannel, [[
+                                                                       title      : "${jobName}, build #${env.BUILD_NUMBER}",
+                                                                       title_link : "${env.BUILD_URL}",
+                                                                       color      : "${buildColor}",
+                                                                       text       : "${buildStatus}\n",
+                                                                       "mrkdwn_in": ["fields"],
+                                                                       fields     : [
+                                                                               [
+                                                                                       title: "Node Name",
+                                                                                       value: "${env.NODE_NAME}",
+                                                                                       short: true
+                                                                               ]
+
+                                                                       ]
+                                                               ],
+                                                               [
+                                                                       title      : "Failed Tests",
+                                                                       color      : "${buildColor}",
+                                                                       text       : "Build Failed",
+                                                                       "mrkdwn_in": ["text"],
+                                                               ]], "${slack_hook_url}")
+                } else {
+                    notifySlack("", slackNotificationChannel, [[
+                                                                       title     : "${jobName}, build #${env.BUILD_NUMBER}",
+                                                                       title_link: "${env.BUILD_URL}",
+                                                                       color     : "${buildColor}",
+                                                                       text      : "${buildStatus}\n",
+                                                                       fields    : [
+                                                                               [
+                                                                                       title: "Node Name",
+                                                                                       value: "${env.NODE_NAME}",
+                                                                                       short: true
+                                                                               ]
+                                                                       ]
+                                                               ]], "${slack_hook_url}")
+                }
+                }else{
+                 echo "slack disabled"
+                echo "Build status ${buildStatus}"
+                }
+            }
+
+        }
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+if [ -z "$VAULT_ADDR" ]
+then
+    echo "Failed to read VAULT_ADDR"
+    exit 1
+fi
+
+if [ -z "$VAULT_CERT_URL" ]
+then
+    echo "Failed to read VAULT_CERT_URL"
+    exit 1
+fi
+
+VERSION=`cat cmd/version.go | grep "const VERSION" | cut -c 17- | tr -d '"'`
+if [ -z "$VERSION" ]
+then
+      echo "Failed to get version from cmd/const.go"
+      exit 1
+fi
+
+echo "Building bmcert ${VERSION}"
+
+docker build \
+    --no-cache \
+    --build-arg version=${VERSION} \
+    --build-arg token=${VAULT_GITHUB_TOKEN} \
+    --build-arg addr=${VAULT_ADDR} \
+    --build-arg url=${VAULT_CERT_URL} \
+    -t bmcert:${VERSION} .
+
+docker create -ti --name artifacts bmcert:${VERSION} bash && \
+    docker cp artifacts:/bmcert-v${VERSION}-linux-amd64.zip bmcert-v${VERSION}-linux-amd64.zip && \
+    docker cp artifacts:/bmcert-v${VERSION}-darwin-amd64.zip bmcert-v${VERSION}-darwin-amd64.zip && \
+    docker cp artifacts:/bmcert-v${VERSION}.SHA256SUMS bmcert-v${VERSION}.SHA256SUMS
+
+# cleanup
+docker rm -fv artifacts &> /dev/null

--- a/cmd/const.go
+++ b/cmd/const.go
@@ -1,3 +1,0 @@
-package cmd
-
-const VERSION = "0.1.3"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/spf13/cobra"
 	pkcs12 "github.com/BlueMedoraPublic/go-pkcs12"
-	"github.com/hashicorp/vault/helper/certutil"
+	"github.com/hashicorp/vault/sdk/helper/certutil"
 )
 
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const VERSION = "0.1.4"
+
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION
- Fixed an import issue with vault's certutil package (path changed)
- Added build system (Dockerfile, build script, Jenkinsfile)

The goal is to provide a consistent method for compiling bmcert. Running `build.sh` will produce an identical artifact as our Jenkins server, while using the latest packages (not relying on previous `go get` operations) 